### PR TITLE
Add find_dependency() for Threads

### DIFF
--- a/cmake/cpp-statsd-clientConfig.cmake.in
+++ b/cmake/cpp-statsd-clientConfig.cmake.in
@@ -1,4 +1,7 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
This fixes downstream packages that import cpp-statsd-client